### PR TITLE
expand compatibility with newer composer versions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,6 @@
 	},
 	"require": {
 		"php": ">=5.3.6",
-		"composer-plugin-api": "1.0.0"
+		"composer-plugin-api": "^1.0"
 	}
 }


### PR DESCRIPTION
composer documentation suggests using version constraint ^1.0.

see https://getcomposer.org/doc/articles/plugins.md
